### PR TITLE
Signup page css change for large screen

### DIFF
--- a/src/_auth/forms/SignupForm.tsx
+++ b/src/_auth/forms/SignupForm.tsx
@@ -106,12 +106,12 @@ const SignupForm = () => {
       </div>
 
       <div className="sm:w-420 flex-center flex-col pt-10">
-        <h3 style={{ color: "#1CC29F" }} className="text-2xl font-bold">
+        <h3 style={{ color: "#1CC29F" }} className="text-2xl font-bold lg:mt-6">
           SignUp
         </h3>
         <form
           onSubmit={form.handleSubmit(handleSignup)}
-          className="flex flex-col gap-5 w-full mt-4">
+          className="flex flex-col gap-5 w-full mt-4 lg:mt-2">
           <FormField
             control={form.control}
             name="name"


### PR DESCRIPTION
Fixes #3 The issue was only for large screen where Signup text was hidden behind the top header navigation.
I have added css for large screen to fix it.
![screencapture-localhost-5173-sign-up-2025-03-10-13_58_24](https://github.com/user-attachments/assets/1de8ed10-9103-409a-b644-1dec7ebb666c)
